### PR TITLE
Add Surge configuration parsing and scaffolding

### DIFF
--- a/custom_config_example.yaml
+++ b/custom_config_example.yaml
@@ -8,35 +8,58 @@ proxies_blacklist:
   - 剩余流量
 
 proxies:
-- name: 🇭🇰 香港
-  type: vless
-  server: 1.1.1.1
-  port: 1234
-  uuid: b691ff92-8576-4e8d-922e-a749cde5f99b
-  network: tcp
-  tls: true
-  udp: true
-  flow: xtls-rprx-vision
-  servername: addons.mozilla.org
-  reality-opts:
-      public-key: xxx
-      short-id: 0
-  client-fingerprint: chrome
+  - name: 🇭🇰 香港
+    type: vless
+    server: 1.1.1.1
+    port: 1234
+    uuid: b691ff92-8576-4e8d-922e-a749cde5f99b
+    network: tcp
+    tls: true
+    udp: true
+    flow: xtls-rprx-vision
+    servername: addons.mozilla.org
+    reality-opts:
+        public-key: xxx
+        short-id: 0
+    client-fingerprint: chrome
 
-- name: 🇺🇸 美国
-  type: vless
-  server: 2.2.2.2
-  port: 1234
-  uuid: 25491ba8-a30a-434c-88ae-161127bf1aaf
-  network: tcp
-  tls: true
-  udp: true
-  flow: xtls-rprx-vision
-  servername: mensura.cdn-apple.com
-  reality-opts:
-      public-key: xxx
-      short-id: 0
-  client-fingerprint: chrome
+  - name: 🇺🇸 美国
+    type: vless
+    server: 2.2.2.2
+    port: 1234
+    uuid: 25491ba8-a30a-434c-88ae-161127bf1aaf
+    network: tcp
+    tls: true
+    udp: true
+    flow: xtls-rprx-vision
+    servername: mensura.cdn-apple.com
+    reality-opts:
+        public-key: xxx
+        short-id: 0
+    client-fingerprint: chrome
 
 rules:
   - DST-PORT,3478,DIRECT
+
+surge:
+  output: /xxx/surge.conf
+  base_sub: https://dler.cloud/subscribe/lHDfhkFUt2dEJpPZIjeG?surge=smart&lv=2%7C3%7C4%7C5%7C6%7C8
+  proxies:
+    - name: 🇭🇰 Snell
+      type: snell
+      server: 3.3.3.3
+      port: 4443
+      psk: example-psk
+      version: 5
+      obfs: shadowtls
+      obfs-host: addons.mozilla.org
+      obfs-password: change-me
+  proxy_groups:
+    - name: 自建Snell
+      type: select
+      proxies:
+        - 🇭🇰 Snell
+        - DIRECT
+      interval: 300
+  rules:
+    - DOMAIN,example.com,自建Snell

--- a/surge_config.py
+++ b/surge_config.py
@@ -1,0 +1,171 @@
+"""Utilities for parsing and manipulating Surge configuration files."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, Iterable, Iterator, List, Optional
+from collections import OrderedDict
+
+
+@dataclass
+class SurgeEntry:
+    """Base class for a parsed Surge configuration line."""
+
+    def to_line(self) -> str:
+        raise NotImplementedError
+
+
+@dataclass
+class SurgeEmptyLine(SurgeEntry):
+    """Represents an empty line within a Surge section."""
+
+    def to_line(self) -> str:
+        return ""
+
+
+@dataclass
+class SurgeComment(SurgeEntry):
+    """Represents a comment line."""
+
+    content: str
+
+    def to_line(self) -> str:
+        return self.content
+
+
+@dataclass
+class SurgeRawLine(SurgeEntry):
+    """Represents a raw line that should be preserved verbatim."""
+
+    content: str
+
+    def to_line(self) -> str:
+        return self.content
+
+
+@dataclass
+class SurgeKeyValue(SurgeEntry):
+    """Represents a key-value pair such as ``foo = bar``."""
+
+    key: str
+    value: str
+
+    def to_line(self) -> str:
+        return f"{self.key} = {self.value}"
+
+
+@dataclass
+class SurgeSection:
+    """A parsed Surge section containing multiple entries."""
+
+    name: str
+    entries: List[SurgeEntry] = field(default_factory=list)
+
+    def __iter__(self) -> Iterator[SurgeEntry]:
+        return iter(self.entries)
+
+    def get(self, key: str) -> Optional[SurgeKeyValue]:
+        for entry in self.entries:
+            if isinstance(entry, SurgeKeyValue) and entry.key == key:
+                return entry
+        return None
+
+    def set(self, key: str, value: str) -> None:
+        existing = self.get(key)
+        if existing is not None:
+            existing.value = value
+        else:
+            self.entries.append(SurgeKeyValue(key=key, value=value))
+
+    def remove(self, key: str) -> None:
+        self.entries = [
+            entry
+            for entry in self.entries
+            if not (isinstance(entry, SurgeKeyValue) and entry.key == key)
+        ]
+
+
+class SurgeConfig:
+    """In-memory representation of a Surge configuration file."""
+
+    def __init__(
+        self,
+        *,
+        managed_config: Optional[str] = None,
+        preamble: Optional[List[str]] = None,
+        sections: Optional[Dict[str, SurgeSection]] = None,
+    ) -> None:
+        self.managed_config = managed_config
+        self.preamble = preamble or []
+        self.sections: "OrderedDict[str, SurgeSection]" = OrderedDict()
+        if sections:
+            for name, section in sections.items():
+                self.sections[name] = section
+
+    def iter_section_names(self) -> Iterable[str]:
+        return self.sections.keys()
+
+    def get_section(self, name: str) -> Optional[SurgeSection]:
+        return self.sections.get(name)
+
+    def ensure_section(self, name: str) -> SurgeSection:
+        section = self.get_section(name)
+        if section is None:
+            section = SurgeSection(name=name)
+            self.sections[name] = section
+        return section
+
+    def to_text(self) -> str:
+        lines: List[str] = []
+        if self.managed_config:
+            lines.append(self.managed_config)
+        lines.extend(self.preamble)
+        for section in self.sections.values():
+            lines.append(f"[{section.name}]")
+            lines.extend(entry.to_line() for entry in section.entries)
+        text = "\n".join(lines)
+        if text and not text.endswith("\n"):
+            text += "\n"
+        return text
+
+    @classmethod
+    def from_text(cls, text: str) -> "SurgeConfig":
+        normalized = text.replace("\r\n", "\n").replace("\r", "\n")
+        lines = normalized.split("\n")
+        managed_config: Optional[str] = None
+        sections: "OrderedDict[str, SurgeSection]" = OrderedDict()
+        preamble: List[str] = []
+        current_section: Optional[SurgeSection] = None
+
+        for idx, line in enumerate(lines):
+            if idx == 0 and line.startswith("#!MANAGED-CONFIG"):
+                managed_config = line
+                continue
+            if line.startswith("[") and line.endswith("]") and len(line) > 2:
+                section_name = line[1:-1]
+                current_section = SurgeSection(name=section_name)
+                sections[section_name] = current_section
+                continue
+            section_name = current_section.name if current_section else None
+            entry = _parse_section_line(line, section_name)
+            if current_section is None:
+                preamble.append(entry.to_line())
+            else:
+                current_section.entries.append(entry)
+
+        return cls(managed_config=managed_config, preamble=preamble, sections=sections)
+
+
+def _parse_section_line(line: str, section: Optional[str]) -> SurgeEntry:
+    if not line:
+        return SurgeEmptyLine()
+    stripped = line.lstrip()
+    if not stripped:
+        return SurgeEmptyLine()
+    if stripped.startswith("#") or stripped.startswith(";"):
+        return SurgeComment(content=line)
+    if section in {"General", "Proxy", "Proxy Group", "Host"} and "=" in line:
+        key, value = line.split("=", 1)
+        return SurgeKeyValue(key=key.strip(), value=value.strip())
+    return SurgeRawLine(content=line)
+

--- a/surge_mix.py
+++ b/surge_mix.py
@@ -1,0 +1,185 @@
+"""Generate a Surge configuration that reuses dlercloud's rules."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from typing import Any, Dict, List
+
+import httpx
+import ruamel.yaml
+
+from surge_config import SurgeConfig, SurgeRawLine
+
+
+def _create_yaml() -> ruamel.yaml.YAML:
+    yaml = ruamel.yaml.YAML()
+    yaml.indent(mapping=4)
+    yaml.encoding = "utf-8"
+    yaml.default_flow_style = False
+    yaml.allow_unicode = True
+    return yaml
+
+
+yaml = _create_yaml()
+
+HEADERS = {"user-agent": "surge-ver/5.0"}
+
+
+@dataclass
+class SurgeProxy:
+    """Representation of a custom Surge proxy entry."""
+
+    name: str
+    type: str
+    options: Dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "SurgeProxy":
+        payload = dict(data)
+        name = payload.pop("name")
+        type_ = payload.pop("type")
+        return cls(name=name, type=type_, options=payload)
+
+    def render_value(self) -> str:
+        parts: List[str] = [self.type]
+        positional: List[str] = []
+        keyed: List[str] = []
+        for key, value in self.options.items():
+            if key in {"server", "host"}:
+                positional.append(str(value))
+            elif key == "port":
+                positional.append(str(value))
+            else:
+                keyed.append(f"{key}={_format_value(value)}")
+        parts.extend(positional)
+        parts.extend(keyed)
+        return ", ".join(parts)
+
+
+@dataclass
+class SurgeProxyGroup:
+    """Representation of a custom Surge proxy group."""
+
+    name: str
+    type: str
+    proxies: List[str] = field(default_factory=list)
+    options: Dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "SurgeProxyGroup":
+        payload = dict(data)
+        name = payload.pop("name")
+        type_ = payload.pop("type")
+        proxies = list(payload.pop("proxies", []))
+        return cls(name=name, type=type_, proxies=proxies, options=payload)
+
+    def render_value(self) -> str:
+        parts: List[str] = [self.type]
+        parts.extend(self.proxies)
+        for key, value in self.options.items():
+            parts.append(f"{key}={_format_value(value)}")
+        return ", ".join(parts)
+
+
+@dataclass
+class SurgeCustomConfig:
+    """User-provided configuration for Surge processing."""
+
+    output: str
+    base_sub: str
+    proxies: List[SurgeProxy] = field(default_factory=list)
+    proxy_groups: List[SurgeProxyGroup] = field(default_factory=list)
+    rules: List[str] = field(default_factory=list)
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "SurgeCustomConfig":
+        output = data["output"]
+        base_sub = data["base_sub"]
+        proxies = [SurgeProxy.from_dict(item) for item in data.get("proxies", [])]
+        proxy_groups = [
+            SurgeProxyGroup.from_dict(item) for item in data.get("proxy_groups", [])
+        ]
+        rules = list(data.get("rules", []))
+        return cls(
+            output=output,
+            base_sub=base_sub,
+            proxies=proxies,
+            proxy_groups=proxy_groups,
+            rules=rules,
+        )
+
+
+def load_custom_config(path: str = "custom_config.yaml") -> Dict[str, Any]:
+    with open(path, "r", encoding="utf-8") as handle:
+        return yaml.load(handle)
+
+
+def fetch_base_config(url: str) -> str:
+    with httpx.Client(headers=HEADERS, timeout=30.0) as client:
+        response = client.get(url)
+        response.raise_for_status()
+        return response.text
+
+
+def ensure_parent_dir(path: str) -> None:
+    directory = os.path.dirname(path)
+    if directory:
+        os.makedirs(directory, exist_ok=True)
+
+
+def apply_custom_proxies(config: SurgeConfig, proxies: List[SurgeProxy]) -> None:
+    if not proxies:
+        return
+    section = config.ensure_section("Proxy")
+    for proxy in proxies:
+        section.set(proxy.name, proxy.render_value())
+
+
+def apply_custom_proxy_groups(config: SurgeConfig, groups: List[SurgeProxyGroup]) -> None:
+    if not groups:
+        return
+    section = config.ensure_section("Proxy Group")
+    for group in groups:
+        section.set(group.name, group.render_value())
+
+
+def apply_custom_rules(config: SurgeConfig, rules: List[str]) -> None:
+    if not rules:
+        return
+    section = config.ensure_section("Rule")
+    for rule in rules:
+        section.entries.append(SurgeRawLine(content=rule))
+
+
+def process_surge_config(raw_config: Dict[str, Any]) -> SurgeConfig:
+    custom = SurgeCustomConfig.from_dict(raw_config)
+    base_text = fetch_base_config(custom.base_sub)
+    surge_config = SurgeConfig.from_text(base_text)
+
+    # The manipulation helpers mirror the Clash workflow but are intentionally
+    # unused for now. Uncomment the following lines once the modification rules
+    # are finalised.
+    # apply_custom_proxies(surge_config, custom.proxies)
+    # apply_custom_proxy_groups(surge_config, custom.proxy_groups)
+    # apply_custom_rules(surge_config, custom.rules)
+
+    ensure_parent_dir(custom.output)
+    with open(custom.output, "w", encoding="utf-8") as handle:
+        handle.write(surge_config.to_text())
+
+    return surge_config
+
+
+def _format_value(value: Any) -> str:
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    return str(value)
+
+
+if __name__ == "__main__":
+    config = load_custom_config()
+    surge_section = config.get("surge")
+    if surge_section:
+        process_surge_config(surge_section)
+


### PR DESCRIPTION
## Summary
- add a reusable parser that can load and serialise Surge configuration files
- introduce a Surge processing script that downloads the base profile and exposes helpers for later customisation
- extend the sample custom configuration with a Surge section describing Snell nodes and groups

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68d369138cac8325b5da202baa8b66d0