### PR TITLE
feat: convert fake-ip-filter to rule mode with force-proxy exceptions

### DIFF
--- a/config_clash_example.yaml
+++ b/config_clash_example.yaml
@@ -30,6 +30,10 @@ proxies:
     reality-opts:
       public-key: example
       short-id: 6ba85179e30d4fc2
+# 强制使用 fake-ip 的域名（即使它们匹配 geosite:cn 等 real-ip 规则）
+# 用于解决某些 CN 域名实际需要代理访问的情况
+fakeip_force_proxy_domains:
+  - bigo.tv
 rules:
   - DST-PORT,3478,DIRECT
   - DOMAIN-SUFFIX,example.com,{ai}

--- a/fakeip_convert.py
+++ b/fakeip_convert.py
@@ -1,0 +1,85 @@
+"""将 Mihomo fake-ip-filter 通配符格式批量转换为 fake-ip-filter-mode: rule 格式。"""
+from __future__ import annotations
+import re
+
+
+def convert_fakeip_filter_entry(entry: str) -> str:
+    """将单条 fake-ip-filter 通配符格式转为 fake-ip-filter-mode: rule 格式。"""
+    entry = entry.strip()
+    if not entry:
+        return ""
+
+    # geosite: / rule-set: 前缀直接映射
+    if entry.startswith("geosite:"):
+        return f"GEOSITE,{entry[len('geosite:'):]},real-ip"
+    if entry.startswith("rule-set:"):
+        return f"RULE-SET,{entry[len('rule-set:'):]},real-ip"
+
+    has_wildcard = "*" in entry or "+" in entry.split(".")[0]
+
+    if not has_wildcard:
+        # 无通配符 → DOMAIN 精确匹配
+        return f"DOMAIN,{entry},real-ip"
+
+    # +.domain（剩余部分无 *）→ DOMAIN-SUFFIX
+    if entry.startswith("+.") and "*" not in entry:
+        return f"DOMAIN-SUFFIX,{entry[2:]},real-ip"
+
+    # *.domain（剩余部分无 *）→ DOMAIN-SUFFIX
+    if re.fullmatch(r"\*\.([^*+]+)", entry):
+        return f"DOMAIN-SUFFIX,{entry[2:]},real-ip"
+
+    # 复杂通配 (time.*.com, +.stun.*.*, *.n.n.srv.*.net) → DOMAIN-REGEX
+    # 按 . 分段，将每段的通配符替换为正则
+    parts = entry.split(".")
+    regex_parts = []
+    for part in parts:
+        if part == "*":
+            regex_parts.append("[^.]*")
+        elif part == "+":
+            regex_parts.append(".*")
+        elif "*" in part:
+            regex_parts.append(re.escape(part).replace(r"\*", "[^.]*"))
+        else:
+            regex_parts.append(re.escape(part))
+    regex = r"\.".join(regex_parts)
+    return f"DOMAIN-REGEX,^{regex}$,real-ip"
+
+
+def convert_fakeip_filters(
+    filters: list[str],
+    force_proxy_domains: list[str] | None = None,
+    append_geosite_cn: bool = True,
+) -> list[str]:
+    """批量转换 fake-ip-filter 列表为 rule 格式。
+
+    force_proxy_domains 中的域名会以 DOMAIN-SUFFIX,xxx,fake-ip 形式
+    插入到列表最前面，优先于后续的 real-ip / geosite:cn 规则。
+
+    append_geosite_cn: 若原 filter 中不含 geosite:cn，自动追加到末尾
+    作为兜底，确保国内域名返回 real-ip 走直连。
+    """
+    rules: list[str] = []
+
+    # 第一部分: 强制 fake-ip 的例外域名（最高优先级）
+    if force_proxy_domains:
+        for domain in force_proxy_domains:
+            domain = domain.strip()
+            if domain:
+                rules.append(f"DOMAIN-SUFFIX,{domain},fake-ip")
+
+    # 第二部分: 原 filter 转换
+    has_geosite_cn = False
+    for entry in filters:
+        stripped = entry.strip()
+        if stripped in ("geosite:cn", "geosite:private,cn"):
+            has_geosite_cn = True
+        converted = convert_fakeip_filter_entry(stripped)
+        if converted:
+            rules.append(converted)
+
+    # 第三部分: 兜底 geosite:cn（确保国内域名走直连，不影响 fasttrack）
+    if append_geosite_cn and not has_geosite_cn:
+        rules.append("GEOSITE,cn,real-ip")
+
+    return rules

--- a/mix_clash.py
+++ b/mix_clash.py
@@ -4,6 +4,7 @@ import subprocess
 import httpx
 import ruamel.yaml
 from copy import deepcopy
+from fakeip_convert import convert_fakeip_filters
 
 yaml = ruamel.yaml.YAML()
 yaml.indent(mapping=4)
@@ -173,6 +174,21 @@ with open("base.yaml", "r", encoding="utf-8") as f:
         print("错误: 基础订阅配置无效或为空")
         os.remove("base.yaml")
         exit(1)
+
+# ── fake-ip-filter 转换为 rule 模式 ──
+dns_section = base.get("dns", {})
+original_filters = dns_section.get("fake-ip-filter")
+force_proxy_domains = clash_config.get("fakeip_force_proxy_domains", [])
+
+if original_filters and isinstance(original_filters, list):
+    print(f"转换 fake-ip-filter: {len(original_filters)} 条 → rule 模式")
+    converted_rules = convert_fakeip_filters(original_filters, force_proxy_domains)
+    dns_section["fake-ip-filter-mode"] = "rule"
+    dns_section["fake-ip-filter"] = converted_rules
+    print(f"  转换完成: {len(converted_rules)} 条规则"
+          f"（含 {len(force_proxy_domains)} 条强制 fake-ip 例外）")
+elif force_proxy_domains:
+    print("警告: 配置了 fakeip_force_proxy_domains 但订阅中无 fake-ip-filter，跳过转换")
 
 # 系统保留代理（不会从 proxy-groups 中移除）
 system_proxies = {"DIRECT", "REJECT"}

--- a/test_fakeip_convert.py
+++ b/test_fakeip_convert.py
@@ -1,0 +1,100 @@
+"""测试 fake-ip-filter 通配符到 rule 模式的转换。"""
+from fakeip_convert import convert_fakeip_filter_entry, convert_fakeip_filters
+
+
+def test_suffix_patterns():
+    """+.xxx 和 *.xxx 都应转为 DOMAIN-SUFFIX"""
+    assert convert_fakeip_filter_entry("+.lan") == "DOMAIN-SUFFIX,lan,real-ip"
+    assert convert_fakeip_filter_entry("+.local") == "DOMAIN-SUFFIX,local,real-ip"
+    assert convert_fakeip_filter_entry("*.lan") == "DOMAIN-SUFFIX,lan,real-ip"
+    assert convert_fakeip_filter_entry("*.pool.ntp.org") == "DOMAIN-SUFFIX,pool.ntp.org,real-ip"
+    assert convert_fakeip_filter_entry("+.music.163.com") == "DOMAIN-SUFFIX,music.163.com,real-ip"
+
+
+def test_exact_domain():
+    """无通配符 → DOMAIN 精确匹配"""
+    assert convert_fakeip_filter_entry("lens.l.google.com") == "DOMAIN,lens.l.google.com,real-ip"
+    assert convert_fakeip_filter_entry("localhost.ptlogin2.qq.com") == "DOMAIN,localhost.ptlogin2.qq.com,real-ip"
+    assert convert_fakeip_filter_entry("musicapi.taihe.com") == "DOMAIN,musicapi.taihe.com,real-ip"
+
+
+def test_middle_wildcard():
+    """中间通配符 → DOMAIN-REGEX"""
+    result = convert_fakeip_filter_entry("time.*.com")
+    assert result == r"DOMAIN-REGEX,^time\.[^.]*\.com$,real-ip"
+
+    result = convert_fakeip_filter_entry("time.*.edu.cn")
+    assert result == r"DOMAIN-REGEX,^time\.[^.]*\.edu\.cn$,real-ip"
+
+    result = convert_fakeip_filter_entry("ntp.*.com")
+    assert result == r"DOMAIN-REGEX,^ntp\.[^.]*\.com$,real-ip"
+
+
+def test_multi_level_wildcard():
+    """+.stun.*.* 等多级通配"""
+    result = convert_fakeip_filter_entry("+.stun.*.*")
+    assert result == r"DOMAIN-REGEX,^.*\.stun\.[^.]*\.[^.]*$,real-ip"
+
+    result = convert_fakeip_filter_entry("+.stun.*.*.*")
+    assert result == r"DOMAIN-REGEX,^.*\.stun\.[^.]*\.[^.]*\.[^.]*$,real-ip"
+
+    result = convert_fakeip_filter_entry("*.n.n.srv.nintendo.net")
+    assert result == "DOMAIN-SUFFIX,n.n.srv.nintendo.net,real-ip"
+
+
+def test_geosite_and_ruleset():
+    """geosite: 和 rule-set: 前缀"""
+    assert convert_fakeip_filter_entry("geosite:cn") == "GEOSITE,cn,real-ip"
+    assert convert_fakeip_filter_entry("geosite:private,cn") == "GEOSITE,private,cn,real-ip"
+    assert convert_fakeip_filter_entry("rule-set:my-cn-rules") == "RULE-SET,my-cn-rules,real-ip"
+
+
+def test_batch_with_force_proxy():
+    """批量转换 + 强制 fake-ip 例外域名"""
+    filters = [
+        "+.lan",
+        "+.local",
+        "time.*.com",
+        "lens.l.google.com",
+        "geosite:cn",
+    ]
+    force = ["bigo.tv", "some-service.com"]
+
+    result = convert_fakeip_filters(filters, force)
+
+    # 强制 fake-ip 的域名在最前面
+    assert result[0] == "DOMAIN-SUFFIX,bigo.tv,fake-ip"
+    assert result[1] == "DOMAIN-SUFFIX,some-service.com,fake-ip"
+
+    # 后续是转换后的 real-ip 规则
+    assert result[2] == "DOMAIN-SUFFIX,lan,real-ip"
+    assert result[3] == "DOMAIN-SUFFIX,local,real-ip"
+    assert result[4] == r"DOMAIN-REGEX,^time\.[^.]*\.com$,real-ip"
+    assert result[5] == "DOMAIN,lens.l.google.com,real-ip"
+    assert result[6] == "GEOSITE,cn,real-ip"
+
+
+def test_batch_without_force():
+    """无例外域名时也正常工作"""
+    filters = ["+.lan", "*.local"]
+    result = convert_fakeip_filters(filters)
+    assert result == ["DOMAIN-SUFFIX,lan,real-ip", "DOMAIN-SUFFIX,local,real-ip"]
+
+
+def test_empty_and_edge_cases():
+    assert convert_fakeip_filter_entry("") == ""
+    assert convert_fakeip_filter_entry("  ") == ""
+    assert convert_fakeip_filters([], []) == []
+    assert convert_fakeip_filters([], None) == []
+
+
+if __name__ == "__main__":
+    test_suffix_patterns()
+    test_exact_domain()
+    test_middle_wildcard()
+    test_multi_level_wildcard()
+    test_geosite_and_ruleset()
+    test_batch_with_force_proxy()
+    test_batch_without_force()
+    test_empty_and_edge_cases()
+    print("所有测试通过!")

--- a/test_integration.py
+++ b/test_integration.py
@@ -1,0 +1,266 @@
+"""集成测试: 模拟真实订阅配置，验证 fake-ip-filter 转换在完整管道中的效果。"""
+from __future__ import annotations
+import ruamel.yaml
+import io
+
+from fakeip_convert import convert_fakeip_filters
+
+yaml = ruamel.yaml.YAML()
+yaml.indent(mapping=4)
+yaml.default_flow_style = False
+yaml.allow_unicode = True
+
+# ── 模拟真实订阅 base.yaml 中的 dns 部分（典型机场配置）──
+MOCK_BASE_DNS = {
+    "enable": True,
+    "listen": "0.0.0.0:7874",
+    "ipv6": True,
+    "enhanced-mode": "fake-ip",
+    "fake-ip-range": "198.18.0.1/16",
+    "fake-ip-filter": [
+        # 本地/保留域名
+        "*.lan",
+        "*.localdomain",
+        "*.example",
+        "*.invalid",
+        "*.localhost",
+        "*.test",
+        "*.local",
+        "*.home.arpa",
+        # NTP 时间同步
+        "time.*.com",
+        "time.*.gov",
+        "time.*.edu.cn",
+        "time.*.apple.com",
+        "time1.*.com",
+        "time2.*.com",
+        "time3.*.com",
+        "time4.*.com",
+        "time5.*.com",
+        "time6.*.com",
+        "time7.*.com",
+        "ntp.*.com",
+        "ntp1.*.com",
+        "ntp2.*.com",
+        "ntp3.*.com",
+        "ntp4.*.com",
+        "*.time.edu.cn",
+        "*.ntp.org.cn",
+        "+.pool.ntp.org",
+        "time1.cloud.tencent.com",
+        # STUN/WebRTC
+        "+.stun.*.*",
+        "+.stun.*.*.*",
+        "+.stun.*.*.*.*",
+        "+.stun.*.*.*.*.*",
+        # Microsoft 网络连接检测
+        "lens.l.google.com",
+        "stun.l.google.com",
+        "stun.*.l.google.com",
+        "+.neverssl.com",
+        "+.msftconnecttest.com",
+        "+.msftncsi.com",
+        # QQ
+        "localhost.ptlogin2.qq.com",
+        "localhost.sec.qq.com",
+        # 游戏平台
+        "+.srv.nintendo.net",
+        "*.n.n.srv.nintendo.net",
+        "+.stun.playstation.net",
+        "xbox.*.microsoft.com",
+        "+.xboxlive.com",
+        # 音乐平台
+        "+.music.163.com",
+        "+.126.net",
+        "musicapi.taihe.com",
+        "music.taihe.com",
+        "songsearch.kugou.com",
+        "trackercdn.kugou.com",
+        "+.kuwo.cn",
+        "api-jooxtt.sanook.com",
+        "d1.music.126.net",
+        "apc.*.musicloud.net",
+        "+.y.qq.com",
+        "+.music.tc.qq.com",
+        "+.stream.qqmusic.qq.com",
+        "amobile.music.tc.qq.com",
+        # Bilibili
+        "+.bilivideo.com",
+        "+.bilivideo.cn",
+        # 国内 CDN / 网络探测
+        "+.hitv.com",
+        "+.mcdn.bilivideo.cn",
+        # GeoSite 规则
+        "geosite:cn",
+    ],
+    "nameserver": [
+        "https://223.5.5.5/dns-query",
+        "https://223.6.6.6/dns-query",
+    ],
+    "nameserver-policy": {
+        "geosite:private,cn": [
+            "https://223.5.5.5/dns-query",
+            "https://223.6.6.6/dns-query",
+        ],
+        "geosite:geolocation-!cn": [
+            "https://1.1.1.1/dns-query",
+            "https://8.8.8.8/dns-query",
+        ],
+    },
+}
+
+# ── 模拟用户的 config_clash.yaml 中的例外域名 ──
+FORCE_PROXY_DOMAINS = ["bigo.tv"]
+
+
+def test_full_pipeline():
+    """模拟 mix_clash.py 中的 fake-ip-filter 转换管道。"""
+    # 复制模拟数据
+    dns_section = dict(MOCK_BASE_DNS)
+    original_filters = dns_section["fake-ip-filter"]
+
+    print(f"原始 fake-ip-filter 条目数: {len(original_filters)}")
+    print(f"强制 fake-ip 域名: {FORCE_PROXY_DOMAINS}")
+    print()
+
+    # ── 执行转换（与 mix_clash.py 中的逻辑一致）──
+    converted_rules = convert_fakeip_filters(original_filters, FORCE_PROXY_DOMAINS)
+    dns_section["fake-ip-filter-mode"] = "rule"
+    dns_section["fake-ip-filter"] = converted_rules
+
+    print(f"转换后规则数: {len(converted_rules)}")
+    print()
+
+    # ── 验证 1: 结构正确性 ──
+    assert dns_section["fake-ip-filter-mode"] == "rule"
+    assert isinstance(dns_section["fake-ip-filter"], list)
+    assert len(dns_section["fake-ip-filter"]) > 0
+    print("[PASS] 结构正确: fake-ip-filter-mode=rule")
+
+    # ── 验证 2: bigo.tv 在最前面，且是 fake-ip ──
+    first_rule = converted_rules[0]
+    assert first_rule == "DOMAIN-SUFFIX,bigo.tv,fake-ip", f"首条规则应为 bigo.tv fake-ip，实际: {first_rule}"
+    print(f"[PASS] 首条规则: {first_rule}")
+
+    # ── 验证 3: geosite:cn 被正确转换且在 bigo.tv 之后 ──
+    cn_rules = [r for r in converted_rules if "GEOSITE,cn" in r]
+    assert len(cn_rules) > 0, "应包含 GEOSITE,cn,real-ip"
+    cn_index = converted_rules.index(cn_rules[0])
+    bigo_index = converted_rules.index(first_rule)
+    assert bigo_index < cn_index, f"bigo.tv({bigo_index}) 应在 geosite:cn({cn_index}) 之前"
+    print(f"[PASS] 优先级正确: bigo.tv(idx={bigo_index}) < geosite:cn(idx={cn_index})")
+
+    # ── 验证 4: 各种模式转换正确 ──
+    checks = {
+        "DOMAIN-SUFFIX,lan,real-ip": "*.lan → DOMAIN-SUFFIX",
+        "DOMAIN-SUFFIX,local,real-ip": "*.local → DOMAIN-SUFFIX",
+        "DOMAIN-SUFFIX,pool.ntp.org,real-ip": "+.pool.ntp.org → DOMAIN-SUFFIX",
+        "DOMAIN,lens.l.google.com,real-ip": "精确域名 → DOMAIN",
+        "DOMAIN,localhost.ptlogin2.qq.com,real-ip": "QQ 精确域名 → DOMAIN",
+        "DOMAIN,time1.cloud.tencent.com,real-ip": "腾讯时间 → DOMAIN",
+        "GEOSITE,cn,real-ip": "geosite:cn → GEOSITE",
+    }
+    for expected, desc in checks.items():
+        assert expected in converted_rules, f"缺失: {expected} ({desc})"
+        print(f"[PASS] {desc}: {expected}")
+
+    # ── 验证 5: 中间通配符转正则 ──
+    time_regex_rules = [r for r in converted_rules if r.startswith("DOMAIN-REGEX") and "time" in r]
+    assert len(time_regex_rules) > 0, "time.*.com 应转为 DOMAIN-REGEX"
+    print(f"[PASS] 中间通配符 → 正则: 共 {len(time_regex_rules)} 条")
+    for r in time_regex_rules[:3]:
+        print(f"       {r}")
+
+    # ── 验证 6: STUN 多级通配符 ──
+    stun_rules = [r for r in converted_rules if "stun" in r]
+    assert len(stun_rules) > 0
+    print(f"[PASS] STUN 规则: 共 {len(stun_rules)} 条")
+    for r in stun_rules[:3]:
+        print(f"       {r}")
+
+    # ── 验证 7: 没有残留的原始通配符格式 ──
+    for r in converted_rules:
+        assert not r.startswith("*."), f"残留原始格式: {r}"
+        assert not r.startswith("+.") or r.startswith("DOMAIN"), f"残留原始格式: {r}"
+    print("[PASS] 无残留通配符格式")
+
+    # ── 验证 8: 生成 YAML 输出可序列化 ──
+    output = io.StringIO()
+    yaml.dump({"dns": dns_section}, output)
+    yaml_text = output.getvalue()
+    assert "fake-ip-filter-mode: rule" in yaml_text
+    assert "DOMAIN-SUFFIX,bigo.tv,fake-ip" in yaml_text
+    assert "GEOSITE,cn,real-ip" in yaml_text
+    print("[PASS] YAML 序列化正常")
+
+    # ── 打印完整转换结果 ──
+    print("\n" + "=" * 60)
+    print("完整转换结果:")
+    print("=" * 60)
+    for i, rule in enumerate(converted_rules):
+        marker = " ◀ FAKE-IP" if rule.endswith(",fake-ip") else ""
+        print(f"  [{i:2d}] {rule}{marker}")
+
+    print(f"\n总计: {len(converted_rules)} 条规则")
+    print(f"  fake-ip (走代理): {sum(1 for r in converted_rules if r.endswith(',fake-ip'))} 条")
+    print(f"  real-ip (直连):   {sum(1 for r in converted_rules if r.endswith(',real-ip'))} 条")
+
+
+def test_bigo_resolution_scenario():
+    """模拟 agent-oss.bigo.tv 的解析场景。
+
+    验证: 在 rule 模式下，bigo.tv 的 DOMAIN-SUFFIX fake-ip 规则
+    优先于 GEOSITE,cn,real-ip，确保该域名获得 Fake-IP。
+    """
+    print("\n" + "=" * 60)
+    print("场景模拟: agent-oss.bigo.tv DNS 解析")
+    print("=" * 60)
+
+    converted = convert_fakeip_filters(
+        MOCK_BASE_DNS["fake-ip-filter"],
+        FORCE_PROXY_DOMAINS,
+    )
+
+    # 模拟 Mihomo 的 rule 匹配逻辑（从上到下，首次匹配）
+    domain = "agent-oss.bigo.tv"
+    result = None
+    matched_rule = None
+
+    for rule in converted:
+        parts = rule.split(",")
+        rule_type = parts[0]
+        action = parts[-1]  # fake-ip 或 real-ip
+
+        if rule_type == "DOMAIN-SUFFIX":
+            suffix = parts[1]
+            if domain == suffix or domain.endswith("." + suffix):
+                result = action
+                matched_rule = rule
+                break
+        elif rule_type == "DOMAIN":
+            if domain == parts[1]:
+                result = action
+                matched_rule = rule
+                break
+        elif rule_type == "GEOSITE":
+            # geosite:cn 包含 bigo.tv（中国公司）
+            # 这里模拟：如果前面没匹配到，geosite:cn 会匹配
+            geo_name = parts[1]
+            if geo_name == "cn":
+                result = action
+                matched_rule = rule
+                break
+
+    print(f"  域名: {domain}")
+    print(f"  匹配规则: {matched_rule}")
+    print(f"  结果: {result}")
+
+    assert result == "fake-ip", f"bigo.tv 应返回 fake-ip，实际: {result}"
+    print(f"\n[PASS] agent-oss.bigo.tv → fake-ip (198.18.x.x) → 走旁路由代理")
+    print(f"[PASS] 不会匹配到 GEOSITE,cn,real-ip（被 DOMAIN-SUFFIX,bigo.tv,fake-ip 优先拦截）")
+
+
+if __name__ == "__main__":
+    test_full_pipeline()
+    test_bigo_resolution_scenario()
+    print("\n✅ 所有集成测试通过!")

--- a/test_real_config.py
+++ b/test_real_config.py
@@ -1,0 +1,187 @@
+"""用真实 nexitally 订阅配置测试 fake-ip-filter 转换。"""
+from __future__ import annotations
+from fakeip_convert import convert_fakeip_filter_entry, convert_fakeip_filters
+
+# 从服务器上 grep 出的真实 fake-ip-filter
+REAL_FILTERS = [
+    "*.lan",
+    "*.localdomain",
+    "*.example",
+    "*.invalid",
+    "*.localhost",
+    "*.test",
+    "*.local",
+    "*.home.arpa",
+    "time.*.com",
+    "time.*.gov",
+    "time.*.edu.cn",
+    "time.*.apple.com",
+    "time1.*.com",
+    "time2.*.com",
+    "time3.*.com",
+    "time4.*.com",
+    "time5.*.com",
+    "time6.*.com",
+    "time7.*.com",
+    "ntp.*.com",
+    "ntp1.*.com",
+    "ntp2.*.com",
+    "ntp3.*.com",
+    "ntp4.*.com",
+    "ntp5.*.com",
+    "ntp6.*.com",
+    "ntp7.*.com",
+    "*.time.edu.cn",
+    "*.ntp.org.cn",
+    "+.pool.ntp.org",
+    "time1.cloud.tencent.com",
+    "stun.*.*",
+    "stun.*.*.*",
+    "swscan.apple.com",
+    "mesu.apple.com",
+    "music.163.com",
+    "*.music.163.com",
+    "*.126.net",
+    "musicapi.taihe.com",
+    "music.taihe.com",
+    "songsearch.kugou.com",
+    "trackercdn.kugou.com",
+    "*.kuwo.cn",
+    "api-jooxtt.sanook.com",
+    "api.joox.com",
+    "y.qq.com",
+    "*.y.qq.com",
+    "streamoc.music.tc.qq.com",
+    "mobileoc.music.tc.qq.com",
+    "isure.stream.qqmusic.qq.com",
+    "dl.stream.qqmusic.qq.com",
+    "aqqmusic.tc.qq.com",
+    "amobile.music.tc.qq.com",
+    "localhost.ptlogin2.qq.com",
+    "*.msftconnecttest.com",
+    "*.msftncsi.com",
+    "*.xiami.com",
+    "*.music.migu.cn",
+    "music.migu.cn",
+    "+.wotgame.cn",
+    "+.wggames.cn",
+    "+.wowsgame.cn",
+    "+.wargaming.net",
+    "*.*.*.srv.nintendo.net",
+    "*.*.stun.playstation.net",
+    "xbox.*.*.microsoft.com",
+    "*.*.xboxlive.com",
+    "*.ipv6.microsoft.com",
+    "teredo.*.*.*",
+    "teredo.*.*",
+    "speedtest.cros.wr.pvp.net",
+    "+.jjvip8.com",
+    "www.douyu.com",
+    "activityapi.huya.com",
+    "activityapi.huya.com.w.cdngslb.com",
+    "www.bilibili.com",
+    "api.bilibili.com",
+    "a.w.bilicdn1.com",
+]
+
+FORCE_PROXY = ["bigo.tv"]
+
+
+def test_real_conversion():
+    print(f"原始 fake-ip-filter: {len(REAL_FILTERS)} 条")
+    print(f"强制 fake-ip 域名: {FORCE_PROXY}")
+    print()
+
+    converted = convert_fakeip_filters(REAL_FILTERS, FORCE_PROXY)
+
+    print(f"转换后规则: {len(converted)} 条")
+    print()
+
+    # 逐条打印，标注类型
+    type_counts = {}
+    errors = []
+    for i, rule in enumerate(converted):
+        parts = rule.split(",")
+        rtype = parts[0]
+        action = parts[-1]
+        type_counts[rtype] = type_counts.get(rtype, 0) + 1
+
+        marker = ""
+        if action == "fake-ip":
+            marker = "  <-- FAKE-IP (走代理)"
+
+        print(f"  [{i:2d}] {rule}{marker}")
+
+        # 基本格式校验
+        if action not in ("real-ip", "fake-ip"):
+            errors.append(f"[{i}] 无效action: {rule}")
+        if rtype not in ("DOMAIN", "DOMAIN-SUFFIX", "DOMAIN-REGEX", "GEOSITE", "RULE-SET"):
+            errors.append(f"[{i}] 无效类型: {rule}")
+
+    print()
+    print("类型统计:")
+    for t, c in sorted(type_counts.items()):
+        print(f"  {t}: {c}")
+
+    if errors:
+        print()
+        print("!! 格式错误:")
+        for e in errors:
+            print(f"  {e}")
+        return False
+
+    # 验证关键点
+    print()
+    assert converted[0] == "DOMAIN-SUFFIX,bigo.tv,fake-ip", f"首条应为 bigo.tv fake-ip: {converted[0]}"
+    print("[PASS] bigo.tv fake-ip 在首位")
+
+    # 验证一些关键转换
+    checks = [
+        ("DOMAIN-SUFFIX,lan,real-ip", "*.lan"),
+        ("DOMAIN-SUFFIX,pool.ntp.org,real-ip", "+.pool.ntp.org"),
+        ("DOMAIN,time1.cloud.tencent.com,real-ip", "time1.cloud.tencent.com"),
+        ("DOMAIN,swscan.apple.com,real-ip", "swscan.apple.com"),
+        ("DOMAIN,music.163.com,real-ip", "music.163.com"),
+        ("DOMAIN-SUFFIX,music.163.com,real-ip", "*.music.163.com"),
+        ("DOMAIN,y.qq.com,real-ip", "y.qq.com"),
+        ("DOMAIN-SUFFIX,y.qq.com,real-ip", "*.y.qq.com"),
+        ("DOMAIN-SUFFIX,wotgame.cn,real-ip", "+.wotgame.cn"),
+        ("DOMAIN,www.bilibili.com,real-ip", "www.bilibili.com"),
+        ("DOMAIN,a.w.bilicdn1.com,real-ip", "a.w.bilicdn1.com"),
+    ]
+    for expected, orig in checks:
+        assert expected in converted, f"缺失: {expected} (原: {orig})"
+        print(f"[PASS] {orig} -> {expected}")
+
+    # 验证复杂通配符
+    print()
+    print("复杂通配符转换验证:")
+    complex_patterns = [
+        "stun.*.*",
+        "stun.*.*.*",
+        "*.*.*.srv.nintendo.net",
+        "*.*.stun.playstation.net",
+        "xbox.*.*.microsoft.com",
+        "*.*.xboxlive.com",
+        "teredo.*.*.*",
+        "teredo.*.*",
+        "time.*.com",
+    ]
+    for pat in complex_patterns:
+        result = convert_fakeip_filter_entry(pat)
+        assert result.startswith("DOMAIN-REGEX,"), f"{pat} 应转为 DOMAIN-REGEX: {result}"
+        # 提取正则部分，验证格式
+        regex_part = result.split(",")[1]
+        assert regex_part.startswith("^") and regex_part.endswith("$"), f"正则应有锚点: {regex_part}"
+        print(f"  [PASS] {pat:40s} -> {result}")
+
+    return True
+
+
+if __name__ == "__main__":
+    ok = test_real_conversion()
+    if ok:
+        print("\n所有测试通过!")
+    else:
+        print("\n测试失败!")
+        exit(1)


### PR DESCRIPTION
## Summary

- Convert subscription's wildcard-based `fake-ip-filter` to Mihomo's `fake-ip-filter-mode: rule` format during config generation
- Support `fakeip_force_proxy_domains` config to force specific domains (e.g. `bigo.tv`) to use fake-ip, overriding `geosite:cn` real-ip rules
- Auto-append `GEOSITE,cn,real-ip` fallback if the subscription doesn't include it, ensuring CN domains still get real IPs for RouterOS fasttrack

## Problem

In a Fake-IP policy routing setup (RouterOS + Mihomo bypass router), domains classified under `geosite:cn` get real IPs instead of fake-ip addresses. This causes domains like `agent-oss.bigo.tv` (HK IP 169.136.125.252, CN-classified) to bypass the proxy, even though they require overseas access.

## Solution

| Original format | Converted rule |
|---|---|
| `*.lan` / `+.lan` | `DOMAIN-SUFFIX,lan,real-ip` |
| `time.*.com` | `DOMAIN-REGEX,^time\.[^.]*\.com$,real-ip` |
| `stun.*.*` | `DOMAIN-REGEX,^stun\.[^.]*\.[^.]*$,real-ip` |
| `lens.l.google.com` | `DOMAIN,lens.l.google.com,real-ip` |
| `geosite:cn` | `GEOSITE,cn,real-ip` |
| (config) `bigo.tv` | `DOMAIN-SUFFIX,bigo.tv,fake-ip` (prepended) |

Rule priority: force-proxy exceptions → original filters → geosite:cn fallback

## Test plan

- [x] Unit tests for all wildcard pattern conversions (`test_fakeip_convert.py`)
- [x] Integration test with real nexitally subscription data (78 entries → 80 rules) (`test_real_config.py`)
- [x] Verified `agent-oss.bigo.tv` matches `DOMAIN-SUFFIX,bigo.tv,fake-ip` before `GEOSITE,cn,real-ip`
- [ ] Deploy to production and verify with `nslookup agent-oss.bigo.tv` returning 198.18.x.x

🤖 Generated with [Claude Code](https://claude.com/claude-code)