### PR TITLE
fix: add default fake-ip-filter when subscription has none

### DIFF
--- a/fakeip_convert.py
+++ b/fakeip_convert.py
@@ -46,8 +46,21 @@ def convert_fakeip_filter_entry(entry: str) -> str:
     return f"DOMAIN-REGEX,^{regex}$,real-ip"
 
 
+# 当订阅无 fake-ip-filter 时使用的默认条目（与 nikki 默认配置对齐）
+DEFAULT_FAKEIP_FILTERS = [
+    "+.lan",
+    "+.local",
+    "geosite:cn",
+    "+.pool.ntp.org",
+    "+.cn",
+    "+.home.arpa",
+    "+.msftconnecttest.com",
+    "+.msftncsi.com",
+]
+
+
 def convert_fakeip_filters(
-    filters: list[str],
+    filters: list[str] | None,
     force_proxy_domains: list[str] | None = None,
     append_geosite_cn: bool = True,
 ) -> list[str]:
@@ -56,9 +69,14 @@ def convert_fakeip_filters(
     force_proxy_domains 中的域名会以 DOMAIN-SUFFIX,xxx,fake-ip 形式
     插入到列表最前面，优先于后续的 real-ip / geosite:cn 规则。
 
-    append_geosite_cn: 若原 filter 中不含 geosite:cn，自动追加到末尾
+    filters 为 None 或空列表时，使用 DEFAULT_FAKEIP_FILTERS 作为基础。
+
+    append_geosite_cn: 若最终 filter 中不含 geosite:cn，自动追加到末尾
     作为兜底，确保国内域名返回 real-ip 走直连。
     """
+    if not filters:
+        filters = list(DEFAULT_FAKEIP_FILTERS)
+
     rules: list[str] = []
 
     # 第一部分: 强制 fake-ip 的例外域名（最高优先级）

--- a/mix_clash.py
+++ b/mix_clash.py
@@ -178,9 +178,17 @@ with open("base.yaml", "r", encoding="utf-8") as f:
 # ── fake-ip-filter 转换为 rule 模式 ──
 dns_section = base.get("dns", {})
 original_filters = dns_section.get("fake-ip-filter")
+original_filter_mode = dns_section.get("fake-ip-filter-mode")
 force_proxy_domains = clash_config.get("fakeip_force_proxy_domains", [])
 
-if original_filters and isinstance(original_filters, list):
+if original_filter_mode == "rule" and force_proxy_domains:
+    # Case 3: 已经是 rule 模式，只需在最前面插入 force-proxy 例外
+    existing_rules = original_filters if isinstance(original_filters, list) else []
+    force_rules = [f"DOMAIN-SUFFIX,{d.strip()},fake-ip" for d in force_proxy_domains if d.strip()]
+    dns_section["fake-ip-filter"] = force_rules + existing_rules
+    print(f"fake-ip-filter 已是 rule 模式，插入 {len(force_rules)} 条 fake-ip 例外")
+elif original_filters and isinstance(original_filters, list):
+    # Case 2: 有 fake-ip-filter（blacklist 通配符格式），转换为 rule 模式
     print(f"转换 fake-ip-filter: {len(original_filters)} 条 → rule 模式")
     converted_rules = convert_fakeip_filters(original_filters, force_proxy_domains)
     dns_section["fake-ip-filter-mode"] = "rule"
@@ -188,7 +196,13 @@ if original_filters and isinstance(original_filters, list):
     print(f"  转换完成: {len(converted_rules)} 条规则"
           f"（含 {len(force_proxy_domains)} 条强制 fake-ip 例外）")
 elif force_proxy_domains:
-    print("警告: 配置了 fakeip_force_proxy_domains 但订阅中无 fake-ip-filter，跳过转换")
+    # Case 1: 无 fake-ip-filter，用默认条目生成
+    print("订阅无 fake-ip-filter，使用默认条目生成 rule 模式")
+    converted_rules = convert_fakeip_filters(None, force_proxy_domains)
+    dns_section["fake-ip-filter-mode"] = "rule"
+    dns_section["fake-ip-filter"] = converted_rules
+    base.setdefault("dns", {}).update(dns_section)
+    print(f"  生成完成: {len(converted_rules)} 条规则")
 
 # 系统保留代理（不会从 proxy-groups 中移除）
 system_proxies = {"DIRECT", "REJECT"}


### PR DESCRIPTION
## Summary

- When subscription has no `fake-ip-filter` section (e.g. dler.cloud), use default entries aligned with nikki's defaults instead of only `GEOSITE,cn,real-ip`

## Default entries

| Entry | Purpose |
|---|---|
| `+.lan` | LAN domain resolution |
| `+.local` | mDNS / local discovery |
| `geosite:cn` | CN domains → real-ip for fasttrack |
| `+.pool.ntp.org` | NTP time sync |
| `+.cn` | .cn TLD fallback |
| `+.home.arpa` | Home network domains |
| `+.msftconnecttest.com` | Windows connectivity check |
| `+.msftncsi.com` | Windows NCSI |

## Why not just GEOSITE,cn?

- LAN/local/home.arpa domains are not in geosite:cn — fake-ip would break internal resolution
- NTP servers are global — fake-ip would break time sync
- msftconnecttest/msftncsi — fake-ip causes Windows to report "no internet"

## Test plan

- [x] `convert_fakeip_filters(None, ['bigo.tv'])` produces 9 rules with defaults
- [x] Existing tests with real subscription data still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)